### PR TITLE
Add yellow bars to the RTStackedChart. Resolves #9

### DIFF
--- a/lib/Util.js
+++ b/lib/Util.js
@@ -62,7 +62,9 @@ export const Util = {
     if (StatesWithIssues[state]) {
       return Constants.graphLineColor;
     }
-    if (val >= 1) {
+    if (high >= 1 && val < 1) {
+      return Constants.yellowColor;
+    } else if (val >= 1) {
       return Constants.redColor;
     } else {
       return Constants.greenColor;

--- a/visualization/StackViz.js
+++ b/visualization/StackViz.js
@@ -425,8 +425,8 @@ export class StackViz {
             { fill: self._disabledColor, opacity: opacity, stroke: stroke },
           ];
         }
-        let high = self.r0ValueAtOffset(series, offset, "r0_h50");
-        let low = self.r0ValueAtOffset(series, offset, "r0_l50");
+        let high = self.r0ValueAtOffset(series, offset, "r0_h80");
+        let low = self.r0ValueAtOffset(series, offset, "r0_l80");
         let val = self.r0ValueAtOffset(series, offset, "r0");
         let fill = Util.colorCodeRt(
           identifier,


### PR DESCRIPTION
If the high value is 1.0 or higher but the estimate is less than 1.0,
the color will be yellow. This affects the bars on the RTStackedChart
as well as the vertical placement line on the state details.